### PR TITLE
`/leap/train-model`: Show an error message for free LeapAI API users

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Just clone, configure, deploy and you have a Headshot AI SaaS in a box.
 
 To create your own Headshot AI app, follow these steps:
 
+> **Note**<br/>Training models is only available on paid plans. Make sure you have an active [Leap AI plan](<[url](https://tryleap.ai/pricing)>) to train models.
+
 1. To setup Supabase/Vercel and your github repo, click on the Vercel Deploy Button and follow the steps.
 
    IMPORTANT: In the Supabase integration step: Make sure you leave the Create sample tables option checked. This might take a few minutes to complete.

--- a/app/leap/train-model/route.ts
+++ b/app/leap/train-model/route.ts
@@ -134,6 +134,27 @@ export async function POST(request: Request) {
     );
 
     const { status, statusText } = resp;
+
+    if (status !== 201) {
+      console.error({ status, statusText });
+      if (status === 400) {
+        return NextResponse.json(
+          {
+            message: "webhookUrl must be a URL address",
+          },
+          { status, statusText }
+        );
+      }
+      if (status === 402) {
+        return NextResponse.json(
+          {
+            message: "Training models is only available on paid plans.",
+          },
+          { status, statusText }
+        );
+      }
+    }
+
     const body = (await resp.json()) as {
       id: string;
       imageSamples: string[];


### PR DESCRIPTION
Models cannot be trained if the user is using a non-subscribed version of LeapAI API.
See: https://tryleap.ai/pricing

This is also referenced in a couple of issues:
 - _by @lok0919 in https://github.com/leap-ai/headshots-starter/issues/51#issuecomment-1752784754_
 - _by @chinmaykunkikar in https://github.com/leap-ai/headshots-starter/issues/44#issuecomment-1756057983_

Change details:
- Instead of users finding out about it at the last stage of local setup,
  warn them earlier before the Local Setup section of the README.
- Show error messages on the toast and on the console for better UX and DX.
	- Status `402` is about not having a premium API
	- Status `400` is about not having a proper webhook url
- Fixes a TypeError (_see https://github.com/leap-ai/headshots-starter/issues/44#issue-1932049482_)

Try it on LeapAI's official playground --
https://reference.tryleap.ai/reference/train