### PR TITLE
docs: Update Supabase dashboard instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ cd {{your-repo-name}}
 
 ### 5. Magic Link Auth (Supabase)
 
-In your supabase [dashboard](https://supabase.com/dashboard/project/{projectId}/auth/templates), click Email Templates -> Magic Link and paste the following template:
+In your supabase [dashboard](https://supabase.com/dashboard/), select newly created project, go to Authentication -> Email Templates -> Magic Link and paste the following template:
 
 ```
 <h2>Magic Link</h2>


### PR DESCRIPTION
Currently project id is not updated during initial clone of the repository, thus leaving it as `{projectId}` which leads to `This project does not exist` error and might make people confused.
For now more clear instructions are fine, but preferable it'd pull `projectId` during setup flow and make appropriate commit to the cloned repository, making the direct link work as expected.
Note that if it's changed to "post clone" update, readme guide on integrations page would not work anyway, so maybe just updating the wording to the one above is even better.