### PR TITLE
Fix Navbar responsiveness issue

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -40,7 +40,7 @@ export default async function Navbar() {
         </Link>
       </div>
       {user && (
-        <div className="hidden lg:flex flex-row gap-2">
+        <div className="lg:flex flex-row gap-2">
           <Link href="/overview">
             <Button variant={"ghost"}>Home</Button>
           </Link>


### PR DESCRIPTION
For smaller screens (width < 1024px) the buttons on the Navbar were disappearing because of hidden property in className